### PR TITLE
Revert "esoTalk to eso"

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,7 +4,7 @@ software in one form or another.
 The eso project is not affiliated with Simon or Toby Zerner and should be
 regarded as a derivative of the esoTalk project.
 
-If you have contributed to the eso project and would like yourself
+If you have contributed to the esoTalk project and would like yourself
 added to this file, please send us an e-mail at contact@geteso.org.
 
 andromidaZ


### PR DESCRIPTION
The forum software is mentioned as "esoTalk" in the contributors file because most of the contributors listed worked on esoTalk instead of the geteso.org software.